### PR TITLE
Prevent LEDs from quickly blinking when on_time == 0 or off_time == 0

### DIFF
--- a/src/LedTask.cpp
+++ b/src/LedTask.cpp
@@ -146,11 +146,12 @@ void LedTask::updateBlinkLed(void) {
     // check to see if it's time to change the state of the LED
     unsigned long current_millis = millis();
 
-    if ((led_state == HIGH) && (current_millis - previous_millis >= on_time)) {
+    if ((led_state == HIGH) && (off_time > 0) &&
+               (current_millis - previous_millis >= on_time)) {
         led_state = LOW;                  //  Turn it off
         previous_millis = current_millis; //  Remember the time
         digitalWrite(led_pin, led_state); //  Update the actual LED
-    } else if ((led_state == LOW) &&
+    } else if ((led_state == LOW) && (on_time > 0) &&
                (current_millis - previous_millis >= off_time)) {
         led_state = HIGH;                 //  Turn it on
         previous_millis = current_millis; //  Remember the time


### PR DESCRIPTION
In some programs a situation when, under certain conditions, LEDs should blink, while in other conditions they should be in the same state (on or off) all the time can appear. In the current code even in situation when on_time or off_time are 0, LEDs would briefly change states (first to the state with time 0 and then back on the next call to updateBlinkLed()).